### PR TITLE
Rename “missing files” to “files not loaded”

### DIFF
--- a/cpc/geofiles/datasets.py
+++ b/cpc/geofiles/datasets.py
@@ -12,8 +12,8 @@ class Dataset:
     """
     def __init__(self, data_type=None):
         self.data_type = data_type
-        self.dates_with_missing_files = set()
-        self.missing_files = set()
+        self.dates_with_files_not_loaded = set()
+        self.files_not_loaded = set()
         self.dates_loaded = set()
 
 

--- a/cpc/geofiles/loading.py
+++ b/cpc/geofiles/loading.py
@@ -168,10 +168,10 @@ def load_ens_fcsts(issued_dates, fhrs, members, file_template, data_type, geogri
                     except ReadingError:
                         # Set this day to missing
                         data_f[f] = np.full((geogrid.num_y * geogrid.num_x), np.nan)
-                        # Add this date to the list of dates with missing files
-                        dataset.dates_with_missing_files.add(date)
-                        # Add this file to the list of missing files
-                        dataset.missing_files.add(file)
+                        # Add this date to the list of dates with files not loaded
+                        dataset.dates_with_files_not_loaded.add(date)
+                        # Add this file to the list of files not loaded
+                        dataset.files_not_loaded.add(file)
             # Take stat over fhr (don't use nanmean/nanstd, if an fhr is missing then we
             # don't trust this mean/std
             if fhr_stat == 'mean':
@@ -303,10 +303,10 @@ def load_dtrm_fcsts(issued_dates, fhrs, file_template, data_type, geogrid, fhr_s
                 except ReadingError:
                     # Set this day to missing
                     data_f[f] = np.full((geogrid.num_y * geogrid.num_x), np.nan)
-                    # Add this date to the list of dates with missing files
-                    dataset.dates_with_missing_files.add(date)
-                    # Add this file to the list of missing files
-                    dataset.missing_files.add(file)
+                    # Add this date to the list of dates with files not loaded
+                    dataset.dates_with_files_not_loaded.add(date)
+                    # Add this file to the list of files not loaded
+                    dataset.files_not_loaded.add(file)
         # Take stat over fhr (don't use nanmean/nanstd, if an fhr is missing then we
         # don't trust this mean/std
         if fhr_stat == 'mean':
@@ -408,10 +408,10 @@ def load_obs(valid_dates, file_template, data_type, geogrid, record_num=None, yr
             except ReadingError:
                 # Set this day to missing
                 dataset.obs[d] = np.full((geogrid.num_y * geogrid.num_x), np.nan)
-                # Add this date to the list of dates with missing files
-                dataset.dates_with_missing_files.add(date)
-                # Add this file to the list of missing files
-                dataset.missing_files.add(file)
+                # Add this date to the list of dates with files not loaded
+                dataset.dates_with_files_not_loaded.add(date)
+                # Add this file to the list of files not loaded
+                dataset.files_not_loaded.add(file)
         elif data_type in ['bin', 'binary']:
             try:
                 # Load data from file
@@ -433,10 +433,10 @@ def load_obs(valid_dates, file_template, data_type, geogrid, record_num=None, yr
             except:
                 # Set this day to missing
                 dataset.obs[d] = np.full((geogrid.num_y * geogrid.num_x), np.nan)
-                # Add this date to the list of dates with missing files
-                dataset.dates_with_missing_files.add(date)
-                # Add this file to the list of missing files
-                dataset.missing_files.add(file)
+                # Add this date to the list of dates with files not loaded
+                dataset.dates_with_files_not_loaded.add(date)
+                # Add this file to the list of files not loaded
+                dataset.files_not_loaded.add(file)
 
     return dataset
 
@@ -542,10 +542,10 @@ def load_climos(valid_days, file_template, geogrid, num_ptiles=None, debug=False
                 dataset.climo[d] = np.full((num_ptiles, geogrid.num_y * geogrid.num_x), np.nan)
             else:
                 dataset.climo[d] = np.full((geogrid.num_y * geogrid.num_x), np.nan)
-            # Add this date to the list of dates with missing files
-            dataset.dates_with_missing_files.add(date)
-            # Add this file to the list of missing files
-            dataset.missing_files.add(file)
+            # Add this date to the list of dates with files not loaded
+            dataset.dates_with_files_not_loaded.add(date)
+            # Add this file to the list of files not loaded
+            dataset.files_not_loaded.add(file)
 
     return dataset
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,7 +71,7 @@ Like for the `reading` module, the `loading` module depends on `wgrib` and `wgri
 
 ### Dataset objects
 
-Data is loaded into a `Dataset` object, from which you can extract the data itself, plus a few QC-related attributes such as dates with missing files, a list of the missing files, and the dates that were loaded. There are several types of `Datasets`. Here is the hierarchy of `Dataset` types, and what information they contain:
+Data is loaded into a `Dataset` object, from which you can extract the data itself, plus a few QC-related attributes such as dates with files not loaded, a list of the files not loaded, and the dates that were loaded. There are several types of `Datasets`. Here is the hierarchy of `Dataset` types, and what information they contain:
 
 - Dataset
   - Observation
@@ -85,8 +85,8 @@ Data is loaded into a `Dataset` object, from which you can extract the data itse
 All `Datasets` contain the following attributes:
 
 - `data_type` - Type of `Dataset` (None for general Datasets)
-- `dates_with_missing_files` - Dates which had at least one file that was missing or couldn't be opened
-- `missing_files` - Files that were missing or couldn't be opened
+- `dates_with_files_not_loaded` - Dates which had at least one file that was missing or couldn't be opened
+- `files_not_loaded` - Files that were missing or couldn't be opened
 - `dates_loaded` - Dates for which data was loaded (includes dates which have all missing data)
 
 #### Observations


### PR DESCRIPTION
Sometimes the files aren’t missing, but they can’t be loaded. This is more accurate to say.